### PR TITLE
Modified "fraction_infected" parameter

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -51,13 +51,13 @@ Each model has its own parameters: in order to completely instantiate the simula
     config = mc.Configuration()
     config.add_model_parameter('beta', 0.001)
     config.add_model_parameter('gamma', 0.01)
-    config.add_model_parameter("fraction_infected", 0.05)
+    config.add_model_parameter("percentage_infected", 0.05)
     model.set_initial_status(config)
 
 The model configuration allows to specify model parameters (as in this scenario) as well as nodes' and edges' ones (e.g.  individual thresholds).
 
-Moreover it allows to specify the initial fraction of infected nodes using the 
-``fraction_infected`` model parameter.
+Moreover it allows to specify the initial percentage of infected nodes using the 
+``percentage_infected`` model parameter.
 
 It is also possible to explicitly specify an initial set of infected nodes: see :ref:`model_conf` for the complete set of use cases.
 
@@ -129,7 +129,7 @@ Multiplots - implemented only for the ``bokeh`` provider - are also useful to co
 	config = mc.Configuration()
 	config.add_model_parameter('beta', 0.001)
 	config.add_model_parameter('lambda', 0.01)
-	config.add_model_parameter("fraction_infected", 0.05)
+	config.add_model_parameter("percentage_infected", 0.05)
 	sis_model.set_initial_status(config)
 	iterations = sis_model.iteration_bunch(200)
 	trends = sis_model.build_trends(iterations)
@@ -142,7 +142,7 @@ Multiplots - implemented only for the ``bokeh`` provider - are also useful to co
 	si_model = si.SIModel(g)
 	config = mc.Configuration()
 	config.add_model_parameter('beta', 0.001)
-	config.add_model_parameter("fraction_infected", 0.05)
+	config.add_model_parameter("percentage_infected", 0.05)
 	si_model.set_initial_status(config)
 	iterations = si_model.iteration_bunch(200)
 	trends = si_model.build_trends(iterations)
@@ -160,7 +160,7 @@ Multiplots - implemented only for the ``bokeh`` provider - are also useful to co
 	for n in g.nodes():
 		config.add_node_configuration("threshold", n, threshold)
 
-	config.add_model_parameter("fraction_infected", 0.30)
+	config.add_model_parameter("percentage_infected", 0.30)
 	th_model.set_initial_status(config)
 	iterations = th_model.iteration_bunch(60)
 	trends = th_model.build_trends(iterations)


### PR DESCRIPTION
Should the "fraction_infected" be "percentage_infected"?

I get a warning with "fraction_infected"

> UserWarning: Initial infection missing: a random sample of 5% of graph nodes will be set as infected