### PR TITLE
Adding a Marker To Ndlib Graph Viz

### DIFF
--- a/ndlib/viz/mpl/ComparisonViz.py
+++ b/ndlib/viz/mpl/ComparisonViz.py
@@ -9,12 +9,12 @@ import matplotlib.pyplot as plt
 import future.utils
 import past
 import six
-
+import itertools
 __author__ = 'Giulio Rossetti'
 __license__ = "BSD-2-Clause"
 __email__ = "giulio.rossetti@gmail.com"
 
-
+marker = itertools.cycle(('D', '+', '>', 'o', '*')) 
 class InitializationException(Exception):
     """Initialization Exception"""
 
@@ -38,7 +38,7 @@ class ComparisonPlot(object):
         for model in models:
             srev = {v: k for k, v in future.utils.iteritems(sts[i])}
             self.nnodes = model.graph.number_of_nodes()
-            for cl in srev.values():
+            for cl in list(srev.values()):
                 available_classes[cl] = None
 
             self.srev["%s_%s" % (model.name, i)] = srev
@@ -76,32 +76,34 @@ class ComparisonPlot(object):
         :param percentile: The percentile for the trend variance area. Default 90.
 
         """
-
+		
         pres = self.iteration_series(percentile)
-
+		
         mx = 0
         i, h = 0, 0
         for k, l in future.utils.iteritems(pres):
+			
             j = 0
             for st in l:
+			
                 mx = len(l[st][0])
                 if self.normalized:
-                    plt.plot(range(0, mx), l[st][1]/self.nnodes, lw=2,
-                             label="%s - %s" % (k.split("_")[0], st), alpha=0.9, color=cols[h+j])
-                    plt.fill_between(range(0,  mx), l[st][0]/self.nnodes,
-                                     l[st][2]/self.nnodes, alpha=0.2, color=cols[h+j])
+                    plt.plot(list(range(0, mx)), l[st][1]/self.nnodes, lw=2,
+                             label="%s - %s" % (k.split("_")[0], st), alpha=0.9,color=cols[h+j])
+                    plt.fill_between(list(range(0,  mx)), l[st][0]/self.nnodes,
+                                     l[st][2]/self.nnodes,alpha=0.2, color=cols[h+j])
                 else:
-                    plt.plot(range(0, mx), l[st][1], lw=2,
-                             label="%s - %s" % (k.split("_")[0], st), alpha=0.9, color=cols[h + j])
-                    plt.fill_between(range(0, mx), l[st][0],
+                    plt.plot(list(range(0, mx)), l[st][1], lw=2,
+                             label="%s - %s" % (k.split("_")[0], st),alpha=0.9, color=cols[h + j])
+                    plt.fill_between(list(range(0, mx)), l[st][0],
                                      l[st][2], alpha=0.2, color=cols[h + j])
                 j += 1
             i += 1
             h += 2
 
         plt.grid(axis="y")
-        plt.xlabel("Iterations", fontsize=24)
-        plt.ylabel(self.ylabel, fontsize=24)
+        plt.xlabel("Iterations", fontsize=20)
+        plt.ylabel(self.ylabel, fontsize=20)
         plt.legend(loc="best", fontsize=18)
         plt.xlim((0, mx))
 

--- a/ndlib/viz/mpl/DiffusionViz.py
+++ b/ndlib/viz/mpl/DiffusionViz.py
@@ -8,12 +8,12 @@ if os.environ.get('DISPLAY', '') == '':
 import matplotlib.pyplot as plt
 import future.utils
 import six
-
+import itertools
 __author__ = 'Giulio Rossetti'
 __license__ = "BSD-2-Clause"
 __email__ = "giulio.rossetti@gmail.com"
 
-
+marker = itertools.cycle(('D', '+', '>', 'o', '*')) 
 @six.add_metaclass(abc.ABCMeta)
 class DiffusionPlot(object):
    # __metaclass__ = abc.ABCMeta
@@ -59,12 +59,12 @@ class DiffusionPlot(object):
         for k, l in future.utils.iteritems(pres):
             mx = len(l[0])
             if self.normalized:
-                plt.plot(range(0, mx), l[1]/self.nnodes, lw=2, label=self.srev[k], alpha=0.5, color=cols[i])
-                plt.fill_between(range(0,  mx), l[0]/self.nnodes, l[2]/self.nnodes, alpha="0.2",
+                plt.plot(list(range(0, mx)), l[1]/self.nnodes, lw=2, label=self.srev[k], alpha=0.5, marker = next(marker),markersize=12, color=cols[i])
+                plt.fill_between(list(range(0,  mx)), l[0]/self.nnodes, l[2]/self.nnodes, alpha="0.2",
                                  color=cols[i])
             else:
-                plt.plot(range(0, mx), l[1], lw=2, label=self.srev[k], alpha=0.5, color=cols[i])
-                plt.fill_between(range(0, mx), l[0], l[2], alpha="0.2",
+                plt.plot(list(range(0, mx)), l[1], lw=2, label=self.srev[k], alpha=0.5, marker = next(marker),markersize=12, color=cols[i])
+                plt.fill_between(list(range(0, mx)), l[0], l[2], alpha="0.2",
                                  color=cols[i])
 
             i += 1


### PR DESCRIPTION
# Ndlib_Marker_Viz

Adding a Marker To Ndlib Graph Viz

Adding marker to Ndlib ComparisonViz and DiffusionViz to distinguish multiple lines and improve visual understanding.

NDlib is a Python software package that allows to describe, simulate, and study diffusion processes on complex networks. The package was design and documentation by Giulia Rossetti you can find examples, tutorials and a complete reference here [ndlib](https://github.com/GiulioRossetti/ndlib).


Matplotlib Marker: a basic matplotlib Marker plot, this shows a few optional features, like defining legend labels, legend size, and maker size.
```python
#Code to plot a simple demo with a “*” marker.
 
import matplotlib.pyplot as plt
x = [1,2,3,4,5]
fig, ax = plt.subplots()
ax.plot(x, '*' , markersize=12, label='(*)')
ax.axis('equal')
leg = ax.legend(fontsize=12);
```
Below are some basic example plots for markers (‘*’, ‘o’ , ’v’ , ‘+’) respectively.

![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/b1.png)
![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/b2.png)
![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/b3.png)
![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/b4.png)

## Assign a unique marker for each plot

Form [Solution 4](hhttps://stackoverflow.com/questions/13091649/unique-plot-marker-for-each-plot-in-matplotlib)in StackOverflow, which answer the question of how to us unique markers for each plot in matplotlib. the solution uses ‘itertools.cycle’ to iterate over a list or tuple indefinitely which picks markers randomly for you. The answer below. 

Python 2.x

```python
import itertools
marker = itertools.cycle((',', '+', '.', 'o', '*')) for n in y:
    plt.plot(x,n, marker = marker.next(), linestyle='')
```
Python 3.x

```python
import itertools
marker = itertools.cycle((',', '+', '.', 'o', '*')) for n in y:
plt.plot(x,n, marker = next(marker), linestyle='')
```

To find the set of All possible markers you can visit matplotlib.markers[2] in matplotlib website (https://matplotlib.org/3.1.0/api/markers_api.html).

## Ndlib Graph Viz
From the documentation of Ndlib, it shown that the model uses matplotlib and bakeh to visualize the diffusion/spreading process and did a good job but Adding markers to a line can be a useful way to distinguish multiple lines or to highlight particular data points. So above solution to add unique markers to all lines.
Instead of visualizing the diffusion process like this:

![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/fs.png)
![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/fs1.png)

It can be visualize like this:

![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/sc.png)
![graph](https://github.com/amshoo/Ndlib_Marker_Viz/tree/master/img/sc1.png)

## Ndlib Marker 
To Add markers to your visualization clone or download this repository. then replace the two python original DiffusionViz.py and ComparisonViz.py with the ones in this repository, I just add three lines of code but everything else in the code is the same as the original files.
