### PR TITLE
fix VCS error

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -22,7 +22,7 @@ You can install the development version with
 
 .. code-block:: python
 
-    pip install git://github.com/GiulioRossetti/ndlib.git
+    pip install git+http://github.com/GiulioRossetti/ndlib.git
 
 ======================
 Installing from source


### PR DESCRIPTION
The previous pip command gives 


```
ERROR: Exception:
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 188, in _main
    status = self.run(options, args)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 185, in wrapper
    return func(self, options, args)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 333, in run
    reqs, check_supported_wheels=not options.target_dir
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 179, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 362, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 314, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 412, in prepare_linked_requirement
    hashes=hashes,
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 180, in unpack_url
    unpack_vcs_link(link, location)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 93, in unpack_vcs_link
    vcs_backend.unpack(location, url=hide_url(link.url))
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/vcs/versioncontrol.py", line 637, in unpack
    self.obtain(location, url=url)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/vcs/versioncontrol.py", line 542, in obtain
    url, rev_options = self.get_url_rev_options(url)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/vcs/versioncontrol.py", line 462, in get_url_rev_options
    secret_url, rev, user_pass = self.get_url_rev_and_auth(url.secret)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/vcs/git.py", line 359, in get_url_rev_and_auth
    url, rev, user_pass = super(Git, cls).get_url_rev_and_auth(url)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/pip/_internal/vcs/versioncontrol.py", line 431, in get_url_rev_and_auth
    "e.g. svn+http://myrepo/svn/MyApp#egg=MyApp".format(url)
ValueError: Sorry, 'git://github.com/GiulioRossetti/ndlib.git' is a malformed VCS url. The format is <vcs>+<protocol>://<url>, e.g. svn+http://myrepo/svn/MyApp#egg=MyApp
```