### PR TITLE
Python 3.8: MPL Hotfix

### DIFF
--- a/ndlib/viz/mpl/DiffusionViz.py
+++ b/ndlib/viz/mpl/DiffusionViz.py
@@ -66,7 +66,7 @@ class DiffusionPlot(object):
             mx = len(l[0])
             if self.normalized:
                 plt.plot(range(0, mx), l[1]/self.nnodes, lw=2, label=self.srev[k], alpha=0.5)  # , color=cols[i])
-                plt.fill_between(range(0,  mx), l[0]/self.nnodes, l[2]/self.nnodes, alpha="0.2")
+                plt.fill_between(range(0,  mx), l[0]/self.nnodes, l[2]/self.nnodes, alpha=0.2)
                     #,color=cols[i])
             else:
                 plt.plot(range(0, mx), l[1], lw=2, label=self.srev[k], alpha=0.5)  # , color=cols[i])


### PR DESCRIPTION
Edits line 69 from `alpha = "0.2"` to `alpha = 0.2`, which fixes the problem presented in Issue #165 using the fix presented in Issue #166. 

No other changes are made, and given it is a bugfix that allows a simulation to run, no comparisons have been made either.