### PR TITLE
Fix multiprocessing numpy random

### DIFF
--- a/ndlib/utils.py
+++ b/ndlib/utils.py
@@ -1,3 +1,4 @@
+import numpy as np
 import multiprocessing
 from contextlib import closing
 import copy
@@ -29,6 +30,7 @@ def multi_runs(model, execution_number=1, iteration_number=50, infection_sets=No
         nprocesses = multiprocessing.cpu_count()
 
     executions = []
+    seeds = np.around(np.random.rand(execution_number)*2**32).astype(int)
 
     if infection_sets is not None:
         if len(infection_sets) != execution_number:
@@ -38,9 +40,9 @@ def multi_runs(model, execution_number=1, iteration_number=50, infection_sets=No
         for x in past.builtins.xrange(0, execution_number, nprocesses):
 
             with closing(multiprocessing.Pool(processes=nprocesses, maxtasksperchild=10)) as pool:
-                tasks = [copy.copy(model).reset(infection_sets[i]) for i in
+                tasks = [(seeds[i], copy.deepcopy(model).reset(infection_sets[i])) for i in
                          past.builtins.xrange(x, min(x + nprocesses, execution_number))]
-                results = [pool.apply_async(__execute, (t, iteration_number)) for t in tasks]
+                results = [pool.apply_async(__execute, (*t, iteration_number)) for t in tasks]
 
             for result in results:
                 executions.append(result.get())
@@ -48,9 +50,9 @@ def multi_runs(model, execution_number=1, iteration_number=50, infection_sets=No
         for x in past.builtins.xrange(0, execution_number, nprocesses):
             with closing(multiprocessing.Pool(processes=nprocesses, maxtasksperchild=10)) as pool:
 
-                tasks = [copy.deepcopy(model).reset() for _ in
+                tasks = [(seeds[i], copy.deepcopy(model).reset()) for _ in
                          past.builtins.xrange(x, min(x + nprocesses, execution_number))]
-                results = [pool.apply_async(__execute, (t, iteration_number)) for t in tasks]
+                results = [pool.apply_async(__execute, (*t, iteration_number)) for t in tasks]
 
             for result in results:
                 executions.append(result.get())
@@ -58,7 +60,7 @@ def multi_runs(model, execution_number=1, iteration_number=50, infection_sets=No
     return executions
 
 
-def __execute(model, iteration_number):
+def __execute(seed, model, iteration_number):
     """
     Execute a simulation model
 
@@ -66,6 +68,7 @@ def __execute(model, iteration_number):
     :param iteration_number: number of iterations
     :return: computed trends
     """
+    np.random.seed(seed)
     iterations = model.iteration_bunch(iteration_number, False)
     trends = model.build_trends(iterations)[0]
     del iterations


### PR DESCRIPTION
### Description of the Bug
Using multiprocessing in Python you come across this problem:
https://stackoverflow.com/questions/9209078/using-python-multiprocessing-with-different-random-seed-for-each-process

### Description of the Change
The possible solution is to explicitly pass a unique random seed to each __execute in ndlib.utils.multiple_run