### PR TITLE
Add forest fire model

### DIFF
--- a/ndlib/models/epidemics/ForestFireModel.py
+++ b/ndlib/models/epidemics/ForestFireModel.py
@@ -84,7 +84,7 @@ class ForestFireModel(DiffusionModel):
             if len(infected_neighbors) >= 1:
                 actual_status[t] = 1
             else:
-                eventp = np.random_sample()
+                eventp = np.random.uniform(0.0, 1.0)
                 if eventp < self.params['model']['f']:
                     actual_status[t] = 1
 
@@ -92,7 +92,7 @@ class ForestFireModel(DiffusionModel):
             actual_status[b] = 2
 
         for r in self.noTree:
-            eventp = np.random_sample()
+            eventp = np.random.uniform(0.0, 1.0)
             if eventp < self.params['model']['p']:
                 actual_status[r] = 0
 

--- a/ndlib/models/epidemics/ForestFireModel.py
+++ b/ndlib/models/epidemics/ForestFireModel.py
@@ -1,0 +1,108 @@
+import numpy as np
+
+from ..DiffusionModel import DiffusionModel
+import future.utils
+
+__author__ = "Mavros Georgios"
+__license__ = "BSD-2-Clause"
+__email__ = "gmavros@protonmail.com"
+
+
+class ForestFireModel(DiffusionModel):
+    """
+        Node Parameters to be specified via ModelConfig
+
+       :param f: Probability with which a tree ignites, even if no neighbor is burning. (float value in [0,1])
+       :param p: Probability with which an empty space fills with a tree .
+    """
+
+    def __init__(self, graph, seed=None):
+        """
+             Model Constructor
+
+             :param graph: A networkx graph object
+         """
+        super(self.__class__, self).__init__(graph, seed)
+        self.available_statuses = {
+            "Susceptible": 0,  # Tree
+            "Infected": 1,  # Burning Tree
+            "Removed": 2  # Empty Space
+        }
+
+        self.parameters = {
+            "model": {
+                "f": {
+                    "descr": "Ignite rate",
+                    "range": [0, 1],
+                    "optional": False},
+                "p": {
+                    "descr": "Recovery rate",
+                    "range": [0, 1],
+                    "optional": False}
+            },
+            "nodes": {},
+            "edges": {},
+        }
+
+        self.tree = []
+        self.burn = []
+        self.noTree = []
+        self.name = "ForestFire"
+
+    def iteration(self, node_status=True):
+        """
+        Execute a single model iteration
+
+        :return: Iteration_id, Incremental node status (dictionary node->status)
+        """
+        self.clean_initial_status(self.available_statuses.values())
+
+        actual_status = {node: nstatus for node, nstatus in future.utils.iteritems(self.status)}
+        self.tree = [node for node, nstatus in future.utils.iteritems(self.status) if
+                     nstatus == self.available_statuses['Susceptible']]
+        self.burn = [node for node, nstatus in future.utils.iteritems(self.status) if
+                     nstatus == self.available_statuses['Infected']]
+        self.noTree = [node for node, nstatus in future.utils.iteritems(self.status) if
+                       nstatus == self.available_statuses['Removed']]
+
+        if self.actual_iteration == 0:
+            self.actual_iteration += 1
+            delta, node_count, status_delta = self.status_delta(actual_status)
+            if node_status:
+                return {"iteration": 0, "status": actual_status.copy(),
+                        "node_count": node_count.copy(), "status_delta": status_delta.copy()}
+            else:
+                return {"iteration": 0, "status": {},
+                        "node_count": node_count.copy(), "status_delta": status_delta.copy()}
+
+        for t in self.tree:
+            if self.graph.directed:
+                infected_neighbors = [v for v in self.graph.successors(t) if self.status[v] == 1]
+            else:
+                infected_neighbors = [v for v in self.graph.neighbors(t) if self.status[v] == 1]
+
+            if len(infected_neighbors) >= 1:
+                actual_status[t] = 1
+            else:
+                eventp = np.random_sample()
+                if eventp < self.params['model']['f']:
+                    actual_status[t] = 1
+
+        for b in self.burn:
+            actual_status[b] = 2
+
+        for r in self.noTree:
+            eventp = np.random_sample()
+            if eventp < self.params['model']['p']:
+                actual_status[r] = 0
+
+        delta, node_count, status_delta = self.status_delta(actual_status)
+        self.status = actual_status
+        self.actual_iteration += 1
+
+        if node_status:
+            return {"iteration": self.actual_iteration - 1, "status": delta.copy(),
+                    "node_count": node_count.copy(), "status_delta": status_delta.copy()}
+        else:
+            return {"iteration": self.actual_iteration - 1, "status": {},
+                    "node_count": node_count.copy(), "status_delta": status_delta.copy()}

--- a/ndlib/models/epidemics/__init__.py
+++ b/ndlib/models/epidemics/__init__.py
@@ -21,6 +21,7 @@ from .GeneralThresholdModel import GeneralThresholdModel
 from .UTLDRModel import UTLDRModel
 from .SEIR_ct_Model import SEIRctModel
 from .SEIS_ct_Model import SEISctModel
+from .ForestFireModel import ForestFireModel
 
 __all__ = [
     'GeneralisedThresholdModel',
@@ -41,5 +42,6 @@ __all__ = [
     'UTLDRModel',
     'ICEPModel',
     'SEIRctModel',
-    'SEISctModel'
+    'SEISctModel',
+    'ForestFireModel'
 ]

--- a/ndlib/test/test_ndlib.py
+++ b/ndlib/test/test_ndlib.py
@@ -308,6 +308,19 @@ class NdlibTest(unittest.TestCase):
             iterations = model.iteration_bunch(10, node_status=False)
             self.assertEqual(len(iterations), 10)
 
+    def test_forest_fire_model(self):
+        for g in get_graph(True):
+            model = epd.ForestFireModel(g)
+            config = mc.Configuration()
+            config.add_model_parameter('f', 0.1)
+            config.add_model_parameter('p', 0.2)
+            config.add_model_parameter("fraction_infected", 0.1)
+            model.set_initial_status(config)
+            iterations = model.iteration_bunch(10)
+            self.assertEqual(len(iterations), 10)
+            iterations = model.iteration_bunch(10, node_status=False)
+            self.assertEqual(len(iterations), 10)
+
     def test_seir_model(self):
 
         for g in get_graph(True):


### PR DESCRIPTION
### Description of the Change

Forest fire model was added. This model is describing Information diffusion proportionally to a forest fire spread.
There are three states : 

* Tree (Susceptible)
* Burning cell (Infected)
* Empty (Removed)

The main algorithm is:

For every iteration:
     A burning cell turns into an empty cell
     A tree will burn if at least one neighbor is burning
     A tree ignites with probability   f   even if no neighbor is burning
     An empty space fills with a tree with probability   p 

We set probabilities "f" and "p". Optional status False. Range [0, 1].

We are defining three lists (sets) in every iteration. Trees(self.tree), Burning cells(self.burn) and empty(self.noTree). In every iteration sets change according to actual_status.

We set actual_set[t] = 1 of every element t of self.tree if such a neighbor of t is a burning cell or if np.random.uniform(0.0, 1.0) < f.
We set actual_set[b] = 2 of every element b of self.burn.
We set actual_set[r] = 0 of every element b of self.noTree if np.random.uniform(0.0, 1.0) < p.


### Alternate Designs

I haven't thing about any

### Possible Drawbacks

I thing none

### Verification Process

A unit test has made just like the other unit tests of models saw in the unit test file.

I tried to figured out if the implementation works right by printing the iterations dict. 
I have confirmed only the non stochastic events : 
* If node in iteration k is in 1 state, in iteration k + 1 goes to 2 state
* If a node (with status 0) in iteration k has such a connected node with status 1, its status in iteration k+1 becomes 1.

### Release Notes

Forest Fire Model added:  Information diffusion description, proportionally to a forest fire spread.
