### PR TITLE
📝 Algorithmic Bias remove note on release in v4 🔬 

### DIFF
--- a/docs/reference/models/opinion/AlgorithmicBias.rst
+++ b/docs/reference/models/opinion/AlgorithmicBias.rst
@@ -2,9 +2,6 @@
 Algorithmic Bias
 ****************
 
-.. note:: The Algorithmic Bias model will be officially released in NDlib 4.0.1
-
-
 The Algorithmic Bias model considers a population of individuals, where each individual holds a continuous opinion  in the interval  [0,1].
 Individuals are connected by a social network, and interact pairwise at discrete time steps.
 The interacting pair is selected from the population at each time point in such a way that individuals that have close opinion values are selected more often, to simulate algorithmic bias.


### PR DESCRIPTION
## 📝Updating documentation?

### Description of the Change
Remove the note at the beginning of the Algorithmic Bias page stating that it _will_ be released in version 4.0.1. Given that the current release is 5.1.1, this is no longer necessary. 

### Release Notes
N/A

