### PR TITLE
Update Halloween2021.rst

### DIFF
--- a/docs/custom/compartments/Halloween2021.rst
+++ b/docs/custom/compartments/Halloween2021.rst
@@ -127,7 +127,7 @@ Things that need to be considered now include:
     model.add_status("Removed")
 
     # Compartment definition
-    c_alpha = cpm.NodeStochastic(0.005, , triggering_status="Susceptible")
+    c_alpha = cpm.NodeStochastic(0.005, triggering_status="Susceptible")
     c_beta = cpm.NodeStochastic(0.0095, triggering_status="Zombie")
     c_gamma = cpm.NodeStochastic(0.0001)
     c_delta = cpm.NodeStochastic(0.0001)
@@ -193,7 +193,7 @@ Thus, the changes to the previous model include:
     model.add_status("Quarantined")
 
     # Compartment definition
-    c_alpha = cpm.NodeStochastic(0.005, , triggering_status="Susceptible")
+    c_alpha = cpm.NodeStochastic(0.005, triggering_status="Susceptible")
     c_beta = cpm.NodeStochastic(0.0095, triggering_status="Zombie")
     c_sigma = cpm.NodeStochastic(0.0001)
     c_delta = cpm.NodeStochastic(0.0001)


### PR DESCRIPTION
## 📝 Are you updating documentation?

### Description of the Change

In the 2021 Halloween Special:
Removed a double comma on the definition of c_alpha ("with cure" and "SIZRQ" example) to avoid a SyntaxError when executing the example.

### Release Notes

Fixed Halloween Special Examples in the documentation.