### PR TITLE
Create initial distribution range for opinion models

### DIFF
--- a/ndlib/models/opinions/ARWHKModel.py
+++ b/ndlib/models/opinions/ARWHKModel.py
@@ -63,6 +63,18 @@ class ARWHKModel(DiffusionModel):
                     "optional": True,
                     "default": 0,
                 },
+                 "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": -1,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": 1,
+                }           
             },
             "edges": {
                 "weight": {
@@ -98,7 +110,7 @@ class ARWHKModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = random.uniform(-1, 1)
+            self.status[node] = np.random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
     """

--- a/ndlib/models/opinions/AlgorithmicBiasMediaModel.py
+++ b/ndlib/models/opinions/AlgorithmicBiasMediaModel.py
@@ -55,6 +55,18 @@ class AlgorithmicBiasMediaModel(DiffusionModel):
                     "range": [0, self.graph.number_of_nodes],
                     "optional": False,
                 },
+                "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 0,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 1,
+                }
             },
             "nodes": {},
             "edges": {},
@@ -76,7 +88,7 @@ class AlgorithmicBiasMediaModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = np.random.random_sample()
+            self.status[node] = np.random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
         ### Initialization numpy representation

--- a/ndlib/models/opinions/AlgorithmicBiasModel.py
+++ b/ndlib/models/opinions/AlgorithmicBiasModel.py
@@ -49,6 +49,18 @@ class AlgorithmicBiasModel(DiffusionModel):
                     "range": [0, 100],
                     "optional": False,
                 },
+                "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 0,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 1,
+                }
             },
             "nodes": {},
             "edges": {},
@@ -69,7 +81,7 @@ class AlgorithmicBiasModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = np.random.random_sample()
+            self.status[node] = np.random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
         ### Initialization numpy representation

--- a/ndlib/models/opinions/CognitiveOpDynModel.py
+++ b/ndlib/models/opinions/CognitiveOpDynModel.py
@@ -80,6 +80,18 @@ class CognitiveOpDynModel(DiffusionModel):
                     "range": [0, 1],
                     "optional": False,
                 },
+                "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 0,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [0, 1],
+                    "optional": True,
+                    "default": 1,
+                }
             },
             "nodes": {},
             "edges": {},
@@ -97,7 +109,7 @@ class CognitiveOpDynModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = np.random.random_sample()
+            self.status[node] = np.random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
         # set new node parameters

--- a/ndlib/models/opinions/HKModel.py
+++ b/ndlib/models/opinions/HKModel.py
@@ -30,6 +30,18 @@ class HKModel(DiffusionModel):
                     "descr": "Bounded confidence threshold",
                     "range": [0, 1],
                     "optional": False,
+                },
+                 "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": -1,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": 1,
                 }
             },
             "edges": {},
@@ -46,7 +58,7 @@ class HKModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = random.uniform(-1, 1)
+            self.status[node] = random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
     def clean_initial_status(self, valid_status=None):

--- a/ndlib/models/opinions/WHKModel.py
+++ b/ndlib/models/opinions/WHKModel.py
@@ -55,6 +55,18 @@ class WHKModel(DiffusionModel):
                     "optional": True,
                     "default": 0,
                 },
+                "init_dist_lower" : {
+                    "descr": "The lower bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": -1,
+                },
+                "init_dist_upper" : {
+                    "descr": "The upper bound of the initial distribution",
+                    "range": [-1, 1],
+                    "optional": True,
+                    "default": 1,
+                }
             },
             "edges": {
                 "weight": {
@@ -90,7 +102,7 @@ class WHKModel(DiffusionModel):
 
         # set node status
         for node in self.status:
-            self.status[node] = random.uniform(-1, 1)
+            self.status[node] = random.uniform(self.params["model"]["init_dist_lower"], self.params["model"]["init_dist_upper"])
         self.initial_status = self.status.copy()
 
     """


### PR DESCRIPTION
For opinion models, this PR seeks to adds optional params to set the range of initial distribution, allowing greater control of model and initial network.

## 💻 Changing functionality: Allow setting initial distribution range for opinion models

### Issue or RFC Endorsed by NDlib's Maintainers
#250 

### Description of the Change
For the opinion models where nodes have a status of [0,1] or [-1,1] (including `AlgorithmicBias`, `WHK`, etc.), it is desirable to be able to set the range of the distribution of the initial status. This fine-tuned control of the starting population can be useful, for instance, in allowing developers to test how models are able to break out of that initial range or to simulate dynamics based on extreme populations.

This PR adds two optional params, `init_dist_lower` and `init_dist_upper` that are then used in the random real value sampling of the selected models.

### Alternate Designs
An alternative would have been to update `add_model_initial_configuration,` however this method seems reserved for node statuses like `Infected` and `Susceptible`, not numerical status values. In addition, `add_model_initial_configuration` asks for setting a specific subset of nodes, but we want to be able to control the initial distribution range of all nodes.

The selected models already had overrides for setting the initial status using real values. This extends that override directly in-line by setting the range of where those real values are drawn from.

### Possible Drawbacks
The `range` attribute of a parameter does not seem to be verified for any params (including existing params like `epsilon`, `gamma.` Therefore, despite setting the correct ranges of [0,1] or [-1,1], these are not enforced and can allow initial condition bounds outside of them.

### Verification Process
I have created multiple different models with various values set for the `init_dist_lower` and `init_dist_upper` params. Because they are directly fed into `np.random.uniform,` it is easy to verify that they accurately set the range: Here, I set `init_dist_lower = 0.95` `init_dist_upper = 1`  

<img width="135" alt="Screen Shot 2023-08-16 at 8 51 36 PM" src="https://github.com/GiulioRossetti/ndlib/assets/56043296/b75119e4-fc91-49c8-aca7-5a291c1e58ce">


Without these params set, we can verify the default behavior preserves the original intended range of the `AlgorithmicBias` model:

<img width="111" alt="Screen Shot 2023-08-16 at 8 52 16 PM" src="https://github.com/GiulioRossetti/ndlib/assets/56043296/4a85e773-63ae-4d8b-af3a-4fce7c6a4a86">

**Note**:  Some models have had their distributions changed to `np.random.uniform,` however this is just a specific sub-version of `np.random.random_sample()` with a defined range. In fact, `np.random.uniform` uses `np.random.random_sample()` under-the-hood. ([Source](https://stackoverflow.com/questions/30030659/in-python-what-is-the-difference-between-random-uniform-and-random-random)) 


### Release Notes

- Create initial distribution range for opinion models