### PR TITLE
Fixed the error about edge_attr dict in cases where edge is defined a…

### DIFF
--- a/ndlib/models/compartments/EdgeCategoricalAttribute.py
+++ b/ndlib/models/compartments/EdgeCategoricalAttribute.py
@@ -23,24 +23,47 @@ class EdgeCategoricalAttribute(Compartiment):
 
     def execute(self, node, graph, status, status_map, *args, **kwargs):
         neighbors = list(graph.neighbors(node))
+        isDiGraph = False #true if the current graph is directed
+        
         if isinstance(graph, nx.DiGraph):
             neighbors = list(graph.predecessors(node))
+            isDiGraph = False
 
         edge_attr = graph.get_edge_attributes(self.attribute)
 
         if self.trigger is not None:
-            triggered = [
-                v
-                for v in neighbors
-                if status[v] == status_map[self.trigger]
-                and edge_attr[(min([node, v]), max([node, v]))] == self.attribute_value
-            ]
+            if(isDiGraph):
+                triggered = [
+                    v
+                    for v in neighbors
+                    if status[v] == status_map[self.trigger]
+                    and edge_attr[(min([node, v]), max([node, v]))] == self.attribute_value
+                ]
+            else:
+                triggered = []
+                for v in neighbors:
+                    if((node, v) in edge_attr):
+                        check = edge_attr[(node, v)]
+                    else: #then graph.has_edge(v, node) is True because v is given as neighbor of node
+                        check = edge_attr[(v, node)]
+                    if status[v] == status_map[self.trigger] and check == self.attribute_value:
+                        triggered.append(v)
         else:
-            triggered = [
-                v
-                for v in neighbors
-                if edge_attr[(min([node, v]), max([node, v]))] == self.attribute_value
-            ]
+            if(isDiGraph):
+                triggered = [
+                    v
+                    for v in neighbors
+                    if edge_attr[(min([node, v]), max([node, v]))] == self.attribute_value
+                ]
+            else:
+                triggered = []
+                for v in neighbors:
+                    if((node, v) in edge_attr):
+                        check = edge_attr[(node, v)]
+                    else:
+                        check = edge_attr[(v, node)]
+                    if check == self.attribute_value:
+                        triggered.append(v)
 
         for _ in triggered:
             p = np.random.random_sample()

--- a/ndlib/models/compartments/EdgeNumericalAttribute.py
+++ b/ndlib/models/compartments/EdgeNumericalAttribute.py
@@ -67,7 +67,10 @@ class EdgeNumericalAttribute(Compartiment):
         if self.trigger is not None:
             for v in neighbors:
                 if status[v] == status_map[self.trigger]:
-                    val = edge_attr[(min([node, v]), max([node, v]))]
+                    if((node, v) in edge_attr):
+                        val = edge_attr[(node, v)]
+                    else:
+                        val = edge_attr[(v, node)]
                     if self.operator == "IN":
                         if self.__available_operators[self.operator][0](
                             val, self.attribute_range[0]
@@ -82,7 +85,10 @@ class EdgeNumericalAttribute(Compartiment):
                             triggered.append(v)
         else:
             for v in neighbors:
-                val = edge_attr[(min([node, v]), max([node, v]))]
+                if((node, v) in edge_attr):
+                    val = edge_attr[(node, v)]
+                else:
+                    val = edge_attr[(v, node)]
                 if self.operator == "IN":
                     if self.__available_operators[self.operator][0](
                         val, self.attribute_range[0]


### PR DESCRIPTION
…s (large num, small num) instead of (small num, large num)

### Identify the Bug

Issue: #253

### Description of the Change

As it is stated in the issue, when edges are not defined like (small number, large number), attribute related to it cannot be found in the edge_attr dictionary. So whenever we try to access a value from that dictionary, we should also check if (large number, small number) version of the edge exists. Not doing this check results in a key error. 

Note: In directed graphs, this change does not apply. Therefore, in EdgeCategorical compartment, we also introduce a flag which is True when the graph is directed. This extra check in edge_attr is done when the graph is undirected.

### Possible Drawbacks

In my tests, I haven't seen any negative impacts or bugs caused by this change. Directed graphs can be inspected further. 

### Verification Process

I have tested with different type of networks generated by networkx library (erdos_renyi_graph, watts_strogatz_graph, random_regular_graph, barabasi_albert_graph) as well as a file input. All graphs were undirected. By inspecting the iteration trends, we can observe that it works as intended. 

### Release Notes

Edge attribute compartments now support undirected edges defined as (large num, small num)