### PR TITLE
Fix depricated bokeh parameter usage

### DIFF
--- a/ndlib/viz/bokeh/DiffusionViz.py
+++ b/ndlib/viz/bokeh/DiffusionViz.py
@@ -56,9 +56,9 @@ class DiffusionPlot(object):
 
             mx = len(l[0])
             if self.normalized:
-                p.line(range(0, mx), l[1] / self.nnodes, line_width=2, legend=self.srev[k], alpha=0.5, color=cols[i])
+                p.line(range(0, mx), l[1] / self.nnodes, line_width=2, legend_label=self.srev[k], alpha=0.5, color=cols[i])
             else:
-                p.line(range(0, mx), l[1], line_width=2, legend=self.srev[k], alpha=0.5, color=cols[i])
+                p.line(range(0, mx), l[1], line_width=2, legend_label=self.srev[k], alpha=0.5, color=cols[i])
 
             i += 1
 


### PR DESCRIPTION
This fixes a keyerror raised in the bokeh library after calling the plot function on various viz classes.

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[9], line 6
      3 from ndlib.viz.bokeh.DiffusionTrend import DiffusionTrend
      5 viz = DiffusionTrend(model, trends)
----> 6 p = viz.plot(width=500, height=400)
      7 show(p)

File ~\anaconda3\Lib\site-packages\ndlib\viz\bokeh\DiffusionViz.py:59, in DiffusionPlot.plot(self, percentile, width, height)
     57 mx = len(l[0])
     58 if self.normalized:
---> 59     p.line(list(range(0, mx)), l[1] / self.nnodes, line_width=2, legend=self.srev[k], alpha=0.5, color=cols[i])
     60 else:
     61     p.line(list(range(0, mx)), l[1], line_width=2, legend=self.srev[k], alpha=0.5, color=cols[i])

File ~\anaconda3\Lib\site-packages\bokeh\plotting\_decorators.py:89, in glyph_method.<locals>.decorator.<locals>.wrapped(self, *args, **kwargs)
     87 if self.coordinates is not None:
     88     kwargs.setdefault("coordinates", self.coordinates)
---> 89 return create_renderer(glyphclass, self.plot, **kwargs)

File ~\anaconda3\Lib\site-packages\bokeh\plotting\_renderer.py:133, in create_renderer(glyphclass, plot, **kwargs)
    127 plot.renderers.append(glyph_renderer)
    129 if legend_kwarg:
    130     # It must be after the renderer is added because
    131     # if it creates a new `LegendItem`, the referenced
    132     # renderer must already be present.
--> 133     update_legend(plot, legend_kwarg, glyph_renderer)
    135 return glyph_renderer

File ~\anaconda3\Lib\site-packages\bokeh\plotting\_legends.py:57, in update_legend(plot, legend_kwarg, glyph_renderer)
     54 legend = _get_or_create_legend(plot)
     55 kwarg, value = next(iter(legend_kwarg.items()))
---> 57 _LEGEND_KWARG_HANDLERS[kwarg](value, legend, glyph_renderer)

KeyError: 'legend'
```