### PR TITLE
Diffusion animator class

### DIFF
--- a/docs/reference/viz/mpl/DiffusionAnimator.rst
+++ b/docs/reference/viz/mpl/DiffusionAnimator.rst
@@ -19,15 +19,15 @@ Below is a minimal example for the SIR model.
 .. code-block:: python
 
     import ndlib.models.ModelConfig as mc
-    import ndlib.models.epidemics as ep
+    import ndlib.models.epidemics as epd
     from ndlib.viz.mpl.DiffusionAnimator import DiffusionAnimator
     import networkx as nx
 
     # Network topology
-    g = nx.erdos_renyi_graph(10, 0.2)
+    g = nx.erdos_renyi_graph(20, 0.2)
 
     # Model selection
-    model = ep.SIRModel(g)
+    model = epd.SIRModel(g)
 
     # Model configuration
     cfg = mc.Configuration()

--- a/docs/reference/viz/mpl/DiffusionAnimator.rst
+++ b/docs/reference/viz/mpl/DiffusionAnimator.rst
@@ -1,0 +1,45 @@
+********************
+Diffusion Animator
+********************
+
+The Diffusion Animator visualises a diffusion process as a frame-by-frame
+animation of the network graph.  Node colours reflect the simulated status at
+each iteration: a categorical palette is used for discrete-state models
+(e.g. SIR) and a sequential colourmap (``RdYlBu_r``) for continuous-opinion
+models.
+
+.. autoclass:: ndlib.viz.mpl.DiffusionAnimator.DiffusionAnimator
+.. automethod:: ndlib.viz.mpl.DiffusionAnimator.DiffusionAnimator.__init__(model, iterations, pos)
+.. automethod:: ndlib.viz.mpl.DiffusionAnimator.DiffusionAnimator.plot()
+.. automethod:: ndlib.viz.mpl.DiffusionAnimator.DiffusionAnimator.save_gif(filename, fps)
+
+
+Below is a minimal example for the SIR model.
+
+.. code-block:: python
+
+    import ndlib.models.ModelConfig as mc
+    import ndlib.models.epidemics as ep
+    from ndlib.viz.mpl.DiffusionAnimator import DiffusionAnimator
+    import networkx as nx
+
+    # Network topology
+    g = nx.erdos_renyi_graph(10, 0.2)
+
+    # Model selection
+    model = ep.SIRModel(g)
+
+    # Model configuration
+    cfg = mc.Configuration()
+    cfg.add_model_parameter('beta', 0.5)
+    cfg.add_model_parameter('gamma', 0.1)
+    cfg.add_model_parameter("fraction_infected", 0.2)
+    model.set_initial_status(cfg)
+
+    # Simulation execution
+    iterations = model.iteration_bunch(20)
+
+    # Animation – returns matplotlib.animation.FuncAnimation
+    viz = DiffusionAnimator(model, iterations)
+    anim = viz.plot()                  # display inline in Jupyter, or …
+    viz.save_gif("sir.gif", fps=3)     # … export as a GIF

--- a/ndlib/test/__init__.py
+++ b/ndlib/test/__init__.py
@@ -5,4 +5,3 @@ from .test_mpl_viz import *
 from .test_ndlib import *
 from .test_parallel import *
 from .test_parser import *
-from .test_viz import *

--- a/ndlib/test/test_mpl_viz.py
+++ b/ndlib/test/test_mpl_viz.py
@@ -10,6 +10,7 @@ from ndlib.viz.mpl.PrevalenceComparison import DiffusionPrevalenceComparison
 from ndlib.viz.mpl.TrendComparison import DiffusionTrendComparison
 from ndlib.viz.mpl.DiffusionTrend import DiffusionTrend
 from ndlib.viz.mpl.OpinionEvolution import OpinionEvolution
+from ndlib.viz.mpl.DiffusionAnimator import DiffusionAnimator
 
 import ndlib.models.ModelConfig as mc
 import ndlib.models.epidemics as epd
@@ -156,6 +157,26 @@ class MplVizTest(unittest.TestCase):
         viz = OpinionEvolution(model, iterations)
         viz.plot("opinion_ev.png")
         os.remove("opinion_ev.png")
+
+    def test_diffusion_animator(self):
+        g = nx.erdos_renyi_graph(10, 0.2)
+
+        model = epd.SIRModel(g)
+
+        # Model configuration
+        cfg = mc.Configuration()
+        cfg.add_model_parameter('beta', 0.5)
+        cfg.add_model_parameter('gamma', 0.1)
+        cfg.add_model_parameter("fraction_infected", 0.2)
+        model.set_initial_status(cfg)
+
+        # Simulation execution
+        iterations = model.iteration_bunch(20)
+
+        viz = DiffusionAnimator(model, iterations)
+        anim = viz.plot()
+        viz.save_gif("sir_test.gif", fps=3)
+        os.remove("sir_test.gif")
 
 
 if __name__ == "__main__":

--- a/ndlib/viz/mpl/DiffusionAnimator.py
+++ b/ndlib/viz/mpl/DiffusionAnimator.py
@@ -109,20 +109,20 @@ class DiffusionAnimator(object):
             ]
             ax.legend(handles=legend_elements, loc="upper right", fontsize=9)
 
-        timestep_text = [None]
+        timestep_text = ax.text(
+            0.05,
+            0.95,
+            "",
+            transform=ax.transAxes,
+            fontsize=9,
+            verticalalignment="top",
+            bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.5),
+        )
 
         def _update(frame):
             nodes_artist.set_facecolor(self._node_colors[frame])
-            if timestep_text[0] is not None:
-                timestep_text[0].remove()
-            timestep_text[0] = ax.text(
-                0.05,
-                0.95,
-                "Iteration: {}".format(self.iterations[frame]["iteration"]),
-                transform=ax.transAxes,
-                fontsize=9,
-                verticalalignment="top",
-                bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.5),
+            timestep_text.set_text(
+                "Iteration: {}".format(self.iterations[frame]["iteration"])
             )
             return (nodes_artist,)
 
@@ -149,4 +149,5 @@ class DiffusionAnimator(object):
             fps=fps,
             savefig_kwargs={"facecolor": "white"},
         )
-        plt.close()
+        animation.event_source.stop()
+        plt.close("all")

--- a/ndlib/viz/mpl/DiffusionAnimator.py
+++ b/ndlib/viz/mpl/DiffusionAnimator.py
@@ -9,9 +9,9 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.lines import Line2D
 import networkx as nx
 
-__author__ = "Giulio Rossetti"
+__author__ = "Peter Carragher"
 __license__ = "BSD-2-Clause"
-__email__ = "giulio.rossetti@gmail.com"
+__email__ = "petercarragher6@gmail.com"
 
 # Categorical palette for discrete-state models (SIR-style)
 _DISCRETE_PALETTE = [

--- a/ndlib/viz/mpl/DiffusionAnimator.py
+++ b/ndlib/viz/mpl/DiffusionAnimator.py
@@ -1,0 +1,152 @@
+import os
+import matplotlib as mpl
+
+if os.environ.get("DISPLAY", "") == "":
+    mpl.use("Agg")
+
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+from matplotlib.lines import Line2D
+import networkx as nx
+
+__author__ = "Giulio Rossetti"
+__license__ = "BSD-2-Clause"
+__email__ = "giulio.rossetti@gmail.com"
+
+# Categorical palette for discrete-state models (SIR-style)
+_DISCRETE_PALETTE = [
+    "#1f77b4",  # blue   – status 0 (Susceptible)
+    "#d62728",  # red    – status 1 (Infected)
+    "#2ca02c",  # green  – status 2 (Recovered)
+    "#ff7f0e",  # orange
+    "#9467bd",  # purple
+    "#8c564b",  # brown
+    "#e377c2",  # pink
+    "#7f7f7f",  # grey
+    "#bcbd22",  # yellow-green
+    "#17becf",  # cyan
+]
+
+
+class DiffusionAnimator(object):
+    def __init__(self, model, iterations, pos=None):
+        """
+        :param model: A configured and executed NDLib diffusion model.
+        :param iterations: Output of ``model.iteration_bunch()``.
+        :param pos: Optional dict mapping node id → (x, y).  If *None*,
+                    a spring layout is computed automatically.
+        """
+        self.model = model
+        self.iterations = iterations
+        self.graph = model.graph.graph
+        self.pos = pos if pos is not None else nx.spring_layout(self.graph)
+
+        # Detect discrete (SIR-style) vs continuous (opinion) model.
+        # Models with more than one named status are treated as discrete.
+        statuses = model.available_statuses
+        self._discrete = len(statuses) > 1
+
+        if self._discrete:
+            self._srev = {v: k for k, v in statuses.items()}
+            unique_ids = sorted(statuses.values())
+            self._status_color = {
+                sid: _DISCRETE_PALETTE[i % len(_DISCRETE_PALETTE)]
+                for i, sid in enumerate(unique_ids)
+            }
+        else:
+            self._cmap = plt.cm.RdYlBu_r
+
+        self._node_colors = self._build_node_colors()
+
+    def _build_node_colors(self):
+        """Return a list (one entry per iteration) of per-node colour arrays."""
+        nodes = list(self.graph.nodes())
+        current = {node: 0 for node in nodes}
+
+        colors_per_iteration = []
+        for it in self.iterations:
+            current.update(it["status"])
+            if self._discrete:
+                frame = [
+                    self._status_color.get(current[node], "#7f7f7f")
+                    for node in nodes
+                ]
+            else:
+                frame = [self._cmap(float(current[node])) for node in nodes]
+            colors_per_iteration.append(frame)
+
+        return colors_per_iteration
+
+    def plot(self):
+        """
+        Build and return a :class:`matplotlib.animation.FuncAnimation` of the
+        diffusion process over the graph.
+
+        The returned object can be displayed inline in a Jupyter notebook or
+        passed to :meth:`save_gif`.
+
+        :return: :class:`matplotlib.animation.FuncAnimation`
+        """
+        fig, ax = plt.subplots()
+        ax.axis("off")
+
+        nodes_artist = nx.draw_networkx_nodes(
+            self.graph, self.pos, node_color=self._node_colors[0], ax=ax
+        )
+        nx.draw_networkx_edges(self.graph, self.pos, ax=ax, alpha=0.3)
+
+        if self._discrete:
+            legend_elements = [
+                Line2D(
+                    [0], [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor=self._status_color[sid],
+                    markersize=10,
+                    label=self._srev[sid],
+                )
+                for sid in sorted(self._status_color)
+            ]
+            ax.legend(handles=legend_elements, loc="upper right", fontsize=9)
+
+        timestep_text = [None]
+
+        def _update(frame):
+            nodes_artist.set_facecolor(self._node_colors[frame])
+            if timestep_text[0] is not None:
+                timestep_text[0].remove()
+            timestep_text[0] = ax.text(
+                0.05,
+                0.95,
+                "Iteration: {}".format(self.iterations[frame]["iteration"]),
+                transform=ax.transAxes,
+                fontsize=9,
+                verticalalignment="top",
+                bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.5),
+            )
+            return (nodes_artist,)
+
+        animation = FuncAnimation(
+            fig,
+            _update,
+            frames=len(self._node_colors),
+            interval=200,
+            blit=True,
+        )
+        return animation
+
+    def save_gif(self, filename, fps=10):
+        """
+        Save the animation as a GIF file.
+
+        :param filename: Output path, e.g. ``"diffusion.gif"``.
+        :param fps: Frames per second (default 10).
+        """
+        animation = self.plot()
+        animation.save(
+            filename,
+            writer="pillow",
+            fps=fps,
+            savefig_kwargs={"facecolor": "white"},
+        )
+        plt.close()

--- a/ndlib/viz/mpl/__init__.py
+++ b/ndlib/viz/mpl/__init__.py
@@ -1,0 +1,1 @@
+from ndlib.viz.mpl.DiffusionAnimator import DiffusionAnimator

--- a/ndlib/viz/mpl/__init__.py
+++ b/ndlib/viz/mpl/__init__.py
@@ -1,1 +1,0 @@
-from ndlib.viz.mpl.DiffusionAnimator import DiffusionAnimator


### PR DESCRIPTION
## Diffusion Animator

Closes: #256 

### Description of the Change

The diffusion animator class outputs animates diffusion processes over time.
It takes as input the iterations output from a diffusion model, and returns a matplotlib FuncAnimation object that can either by rendered directly in a jupyter notebook cell, or converted into a GIF.
Among other things, this is designed to be a teaching aid for making network diffusion presentations.

### Alternate Designs

Considered making this a webapp, similar to this [earlier standalone attempt](https://github.com/PeterCarragher/diffusion_animator)

### Possible Drawbacks

Non-essential code for NDLib that could be viewed as technical debt.

### Verification Process

- Added a test case to ndlib/test/test_mpl_viz.py
- Generated the below GIF

### Release Notes

- Added a diffusion animator class to the viz utilities that outputs gifs of diffusion processes evolving over time.

![sir](https://github.com/user-attachments/assets/d92d3d93-27db-454e-8477-89a387a2aba6)